### PR TITLE
sepolicy: drop allow non existing uci_device type

### DIFF
--- a/sepolicy/init.te
+++ b/sepolicy/init.te
@@ -1,4 +1,3 @@
 allow init dmabuf_system_heap_device:chr_file { ioctl open read };
 allow init faceauth_heap_device:chr_file { ioctl open read };
-allow init uci_device:chr_file { ioctl open read write };
 allow init edgetpu_device:chr_file { ioctl open read write };


### PR DESCRIPTION
* Was originally pulled from husky, older devices like cheetah don't have this policy. Turns out it's not needed anyways for faceunlock to work correctly. So just remove it.